### PR TITLE
feat: include tavily secret if available in requests

### DIFF
--- a/examples/agents.ts
+++ b/examples/agents.ts
@@ -77,7 +77,6 @@ async function main() {
     );
 
     // Log the response events
-
     for await (const chunk of response) {
         if (chunk.event.payload.event_type === 'turn_complete') {
             console.log(chunk.event.payload.turn.output_message);

--- a/examples/agents.ts
+++ b/examples/agents.ts
@@ -2,8 +2,14 @@
 
 import { AgentConfig } from "llama-stack-client/resources/shared";
 
-import LlamaStackClient from 'llama-stack-client';
-const client = new LlamaStackClient({ baseURL: 'http://localhost:8321' });
+import { LlamaStackClient, ClientOptions } from 'llama-stack-client';
+
+const options: ClientOptions = { baseURL: 'http://localhost:8321' };
+if (process.env["TAVILY_SEARCH_API_KEY"]) {
+  const tavilyHeader = JSON.stringify({tavily_search_api_key: process.env["TAVILY_SEARCH_API_KEY"]});
+  options.defaultHeaders = { 'X-LlamaStack-Provider-Data': tavilyHeader  }
+}
+const client = new LlamaStackClient(options);
 
 async function main() {
   const availableModels = (await client.models.list())
@@ -71,6 +77,7 @@ async function main() {
     );
 
     // Log the response events
+
     for await (const chunk of response) {
         if (chunk.event.payload.event_type === 'turn_complete') {
             console.log(chunk.event.payload.turn.output_message);


### PR DESCRIPTION
- without this change the secret must also be provided in the llama-stack environment which too me a little while to figure out
- makes it a bit more consistent with the python example in https://github.com/meta-llama/llama-stack-apps/blob/592a101c155082125d8f1170cf4824860a0fd921/examples/agents/hello.py#L24